### PR TITLE
修复 san-hot-loader 的 store 单测

### DIFF
--- a/packages/san-hot-loader/__tests__/store/mock/store.js
+++ b/packages/san-hot-loader/__tests__/store/mock/store.js
@@ -36,13 +36,6 @@ export const noGlobalActions = [
     `
     import {store} from 'san-store';
     import {builder} from 'san-update';
-    store.addAction('count', function (num) {
-        return builder().set('num', num);
-    })
-    `,
-    `
-    import {store} from 'san-store';
-    import {builder} from 'san-update';
     `,
 
     `

--- a/packages/san-hot-loader/lib/store/match-by-ast.js
+++ b/packages/san-hot-loader/lib/store/match-by-ast.js
@@ -26,10 +26,6 @@ module.exports = function (ast) {
     if (hasModuleHot(ast)) {
         return false;
     }
-    let defaultModule = getExportDefault(ast);
-    if (!defaultModule) {
-        return false;
-    }
 
     if (!isModuleImported(ast, 'san-store')) {
         return false;


### PR DESCRIPTION
hmr 在 san-store 语法检测这块有分为全局 store 和自定义 store 两种，其中全局 store 是不需要强制 export default 的，因此需要将相关逻辑去除，并修改单测