### PR TITLE
san-loader 支持 CSS Modules

### DIFF
--- a/packages/san-loader/README.md
+++ b/packages/san-loader/README.md
@@ -305,3 +305,225 @@ style 模块用来书写组件的样式，在用法上与 template、script 类�
 <style src="./component-style.styl"></style>
 ```
 
+## CSS Modules
+
+### 基本使用
+
+[CSS Modules][css-modules] 是一个流行的用于模块化和组合 CSS 的系统，san-loader 提供了与 css-loader 的集成以支持 CSS Modules 的特性。在模板中可以这样写：
+
+```html
+<template>
+    <div class="{{$style.wrapper}}"></div>
+</template>
+
+<script>
+export default {
+    attached() {
+        let style = this.data.get('$style');
+        console.log(style);
+    }
+}
+</script>
+
+<style module>
+.wrapper {
+    color: black;
+}
+</style>
+```
+
+如果要对所有文件生效，在上面的 webpack 配置示例中给 css-loader 添加 `modules` 参数即可。例如：
+
+```javascript
+// webpack.config.js 省略上下文
+rules: [
+    {
+        test: /\.css$/,
+        use: [
+            'style-loader',
+            {
+                loader: 'css-loader',
+                options: {
+                    modules: {
+                        localIdentName: '[local]_[hash:base64:5]'
+                    },
+                    localsConvention: 'camelCase',
+                    sourceMap: true
+                }
+            }
+        ]
+    }
+]
+```
+
+其中 `localIdentName` 用来指定编译后的类名，在开发环境请使用 `'[hash:base64]'`；
+`localsConvention` 是在模板和 JavaScript 中引用的名称，默认是不转换，`'camelCase'` 是把类名转换为驼峰风格。详情请参考：[css-loader 文档][css-loader]。
+
+### 允许非 CSS Modules
+
+也可以指定部分 style 标签使用 CSS Modules，其他仍然是普通的全局 CSS：
+
+```html
+<style module>
+/* 这里是 CSS Modules */
+</style>
+
+<style>
+/* 这里是全局 CSS */
+</style>
+```
+
+san-loader 会给带 `module` 的 `<style>` 添加对应的 `resourceQuery`，所以你可以这样配置：
+
+```javascript
+// webpack.config.js 省略上下文
+rules: [
+    {
+        test: /\.css$/,
+        oneOf: [
+            // 这里匹配 `<style module>`
+            {
+                resourceQuery: /module/,
+                use: [
+                    'style-loader',
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: {
+                                localIdentName: '[local]_[hash:base64:5]',
+                            },
+                            localsConvention: 'camelCase',
+                            sourceMap: true
+                        }
+                    }
+                ]
+            },
+            // 这里匹配 `<style>`
+            {
+                use: [
+                    {
+                        loader: 'style-loader'
+                    },
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: true
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+]
+```
+
+### 和预处理器一起使用
+
+你也可以把 CSS Modules 和 LESS 等预处理器一起使用，添加对应的 loader 即可。比如：
+
+```javascript
+// webpack.config.js 省略上下文
+rules: [
+    {
+        test: /\.less$/,
+        oneOf: [
+            // 这里匹配 `<style lang="less" module>`
+            {
+                resourceQuery: /module/,
+                use: [
+                    'style-loader',
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: {
+                                localIdentName: '[local]_[hash:base64:5]'
+                            },
+                            localsConvention: 'camelCase',
+                            sourceMap: true
+                        }
+                    },
+                    {
+                        loader: 'less-loader',
+                        options: {
+                            sourceMap: true
+                        }
+                    }
+                ]
+            },
+            // 这里匹配 `<style lang="less">`
+            // ...
+        ]
+    }
+]
+```
+
+### 一些有用的用例
+
+CSS Modules 可以在使用 slot 时使用（会被编译到随机的类名）：
+
+```html
+<template>
+    <div>
+        <child-component>
+            <span class="{{$style.bold}}">foo</span>
+        </child-component>
+    </div>
+</template>
+
+<style module>
+.bold {
+    font-weight: bold;
+}
+</style>
+```
+
+也可以设置子组件的根元素样式（会被正确编译到随机类名）：
+
+```html
+<template>
+    <div>
+        <child-component class="child"></child-component>
+    </div>
+</template>
+
+<style module>
+.child {
+    font-weight: bold;
+}
+</style>
+```
+
+但父组件无法覆盖子组件的内部类的样式，比如子组件内存在类名 `.foo`，父组件里的 `.child .foo` 不会渗透进入子组件：
+
+```html
+<template>
+    <div>
+        <child-component class="child"></child-component>
+    </div>
+</template>
+
+<style module>
+.child .foo {
+    font-weight: bold;
+}
+</style>
+```
+
+但除类名之外的元素名、ID 等会渗透进入子组件，例如下面的 `.child span` 会作用于 `<child-component>` 里的 `<span>`：
+
+```html
+<template>
+    <div>
+        <child-component class="child"></child-component>
+    </div>
+</template>
+
+<style module>
+.child span {
+    font-weight: bold;
+}
+</style>
+```
+
+[css-modules]: https://github.com/css-modules/css-modules
+[css-loader]: https://github.com/webpack-contrib/css-loader#localsconvention

--- a/packages/san-loader/__tests__/load-san-entry.spec.js
+++ b/packages/san-loader/__tests__/load-san-entry.spec.js
@@ -11,6 +11,27 @@ const loader = require('../lib/loader');
 const webpackContext = require('./webpack-context.stub');
 
 describe('.san 文件的产出', () => {
+    test('整体框架', () => {
+        const source = `
+        <template>
+            <span class="{{$style.red}}">Author: harttle</span>
+        </template>
+        <style module>.red { color: red }</style>
+        <script>
+            export default class CompComponent extends Component {
+                attached() { console.log('attached') }
+            }
+        </script>
+        `;
+        const ctx = webpackContext({resourcePath: '/foo.san'}).runLoader(loader, source);
+        expect(ctx.code).toContain('import normalize from');
+        expect(ctx.code).toContain('import template from');
+        expect(ctx.code).toContain('import script from');
+        expect(ctx.code).toContain('import style0 from');
+        expect(ctx.code).toContain('let injectStyles = [style0]');
+        expect(ctx.code).toContain('export default normalize(script, template, injectStyles)');
+    });
+
     test('import <template> 部分', () => {
         const source = '<template><span>Author: harttle</span></template>';
         const ctx = webpackContext({resourcePath: '/foo.san'}).runLoader(loader, source);
@@ -21,6 +42,18 @@ describe('.san 文件的产出', () => {
         const source = '<style>p {color: black}</style>';
         const ctx = webpackContext({resourcePath: '/foo.san'}).runLoader(loader, source);
         expect(ctx.code).toContain('import \'/foo.san?lang=css&san=&type=style&index=0');
+    });
+
+    test('import <style module>', () => {
+        const source = '<style module>p {color: black}</style>';
+        const ctx = webpackContext({resourcePath: '/foo.san'}).runLoader(loader, source);
+        expect(ctx.code).toContain('import style0 from \'/foo.san?lang=css&module=&san=&type=style&index=0');
+    });
+
+    test('import <style module src="./s.less">', () => {
+        const source = '<style module src="./s.less"></style>';
+        const ctx = webpackContext({resourcePath: '/foo.san'}).runLoader(loader, source);
+        expect(ctx.code).toContain('import style0 from \'./s.less?module=\'');
     });
 
     test('import <script> 部分', () => {

--- a/packages/san-loader/examples/src/App.san
+++ b/packages/san-loader/examples/src/App.san
@@ -1,11 +1,14 @@
 <template>
     <div class="app-root">
         <span class="app-span">Hello, {{name}}</span>
-        <div class="comp-wrapper">
-            <comp-child age="2"></comp-child>
+        <div class="{{$style.wrapper}}">
+            <comp-child age="2">
+                <span class="{{$style.parent}}" slot="parent">x{{name}}</span>
+                <span slot="age">{{age}}</span>
+            </comp-child>
             <comp-component age="2"></comp-component>
             <comp-component age="2.5"></comp-component>
-            <comp-custom-store age="3"></comp-custom-store>
+            <comp-custom-store class="{{$style.customStore}}" age="3"></comp-custom-store>
             <comp-global-store age="4"></comp-global-store>
             <comp-src age="5"></comp-src>
             <comp-globalstorejs age="6"></comp-globalstorejs>
@@ -52,14 +55,29 @@ export default {
 <style lang="less">
 .app-root {
     .app-span {
-        color: #f2f3f5;
+        color: green;
     }
 }
 </style>
 
 <style>
 .app-span {
-    border: 1px solid black;
+    font-size: 2rem;
+}
+</style>
+
+<style module>
+.wrapper {
+    color: #333;
+}
+.wrapper .custom-store {
+    color: #fff;
+}
+.wrapper .custom-store span {
+    font-weight: bold;
+}
+.parent {
+    color: green;
 }
 </style>
 

--- a/packages/san-loader/examples/src/components/comp-child/SubComponent.san
+++ b/packages/san-loader/examples/src/components/comp-child/SubComponent.san
@@ -1,6 +1,10 @@
 <template>
     <div class="comp-sub-component">
-        <div>this is <span>{{name}}</span>, the age is <span>{{age}}</span></div>
+        <div>
+            this is <span>{{name}}</span>,
+            the parent is "<slot></slot>",
+            the age is <span>{{age}}</span>
+        </div>
         <div><button on-click="click">clicked {{clicked.time}} times</button></div>
     </div>
 </template>

--- a/packages/san-loader/examples/src/components/comp-child/index.san
+++ b/packages/san-loader/examples/src/components/comp-child/index.san
@@ -1,8 +1,12 @@
 <template>
     <div class="comp-child">
-        <div>this is <span>{{name}}</span>, the age is <span>{{age}}</span></div>
+        <div>
+            this is <span>{{name}}</span>,
+            the parent is "<slot name="parent"></slot>",
+            the age is <slot name="age"></slot>
+        </div>
         <div><button on-click="click">clicked {{clicked.time}} times</button></div>
-        <sub-component age="{{clicked.time + 1}}"></sub-component>
+        <sub-component age="{{clicked.time + 1}}"><slot name="parent"></slot></sub-component>
     </div>
 </template>
 

--- a/packages/san-loader/examples/src/components/comp-component.san
+++ b/packages/san-loader/examples/src/components/comp-component.san
@@ -1,5 +1,5 @@
 <template>
-    <div class="comp-component">
+    <div class="{{ $style.compComponent }}">
         <div>this is <span>{{name}}</span>, the age is <span>{{age}}</span></div>
         <div><button on-click="click">clicked {{clicked.time}} times</button></div>
     </div>
@@ -37,7 +37,7 @@ console.log(`---- ${name} File loaded ----`)
 
 </script>
 
-<style lang="less">
+<style lang="less" module>
 .comp-component {
     background: green;
 }

--- a/packages/san-loader/examples/src/components/comp-custom-store.san
+++ b/packages/san-loader/examples/src/components/comp-custom-store.san
@@ -1,5 +1,5 @@
 <template>
-    <div class="comp-custom-store">
+    <div class="{{$style.compCustomStore}}">
         <div>this is <span>{{name}}</span>, the age is <span>{{age}}</span></div>
         <div><button on-click="click">clicked {{time}} times</button></div>
     </div>
@@ -45,7 +45,7 @@ console.log(`---- ${name} File loaded ----`);
 
 </script>
 
-<style lang="less">
+<style lang="less" module>
 .comp-custom-store {
     background: grey;
 }

--- a/packages/san-loader/examples/src/components/comp-src/index.san
+++ b/packages/san-loader/examples/src/components/comp-src/index.san
@@ -1,3 +1,3 @@
 <template src="./template.html"></template>
 <script src="./script.js"></script>
-<style src="./style.less"></style>
+<style module src="./style.less"></style>

--- a/packages/san-loader/examples/src/components/comp-src/template.html
+++ b/packages/san-loader/examples/src/components/comp-src/template.html
@@ -1,4 +1,4 @@
-<div class="comp-src">
+<div class="{{ $style.compSrc }}">
     <div>this is <span>{{name}}</span>, the age is <span>{{age}}</span></div>
     <div><button on-click="click" type="button">clicked {{clicked.time}} times</button></div>
 </div>

--- a/packages/san-loader/examples/webpack.config.js
+++ b/packages/san-loader/examples/webpack.config.js
@@ -91,47 +91,85 @@ module.exports = {
             },
             {
                 test: /\.less$/,
-                use: [
-                    // {
-                    //     loader: MiniCssExtractPlugin.loader,
-                    //     options: {
-                    //         esModule: true
-                    //     }
-                    // },
+                oneOf: [
+                    // 这里匹配 `<style lang="less" module>`
                     {
-                        loader: 'style-loader'
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    modules: {
+                                        localIdentName: '[local]_[hash:base64:5]'
+                                    },
+                                    localsConvention: 'camelCase',
+                                    sourceMap: true
+                                }
+                            },
+                            {
+                                loader: 'less-loader',
+                                options: {
+                                    sourceMap: true
+                                }
+                            }
+                        ]
                     },
+                    // 这里匹配 `<style lang="less">`
                     {
-                        loader: 'css-loader',
-                        options: {
-                            sourceMap: true
-                        }
-                    },
-                    {
-                        loader: 'less-loader',
-                        options: {
-                            sourceMap: true
-                        }
+                        use: [
+                            {
+                                loader: 'style-loader'
+                            },
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    sourceMap: true
+                                }
+                            },
+                            {
+                                loader: 'less-loader',
+                                options: {
+                                    sourceMap: true
+                                }
+                            }
+                        ]
                     }
                 ]
             },
             {
                 test: /\.css$/,
-                use: [
-                    // {
-                    //     loader: MiniCssExtractPlugin.loader,
-                    //     options: {
-                    //         esModule: true
-                    //     }
-                    // },
+                oneOf: [
+                    // 这里匹配 `<style module>`
                     {
-                        loader: 'style-loader'
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    modules: {
+                                        localIdentName: '[local]_[hash:base64:5]',
+                                    },
+                                    localsConvention: 'camelCase',
+                                    sourceMap: true
+                                }
+                            }
+                        ]
                     },
+                    // 这里匹配 `<style>`
                     {
-                        loader: 'css-loader',
-                        options: {
-                            sourceMap: true
-                        }
+                        use: [
+                            {
+                                loader: 'style-loader'
+                            },
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    sourceMap: true
+                                }
+                            }
+                        ]
                     }
                 ]
             },

--- a/packages/san-loader/lib/loader.js
+++ b/packages/san-loader/lib/loader.js
@@ -95,10 +95,9 @@ module.exports = function (source) {
         ${styleCode}
         ${templateCode}
         ${scriptCode}
-        export default normalize(script, template);
+        export default normalize(script, template, injectStyles);
         /* san-hmr component */
     `;
-
     this.callback(null, codo);
 };
 


### PR DESCRIPTION
scoped CSS 和 CSS Modules 都可以实现样式的封装，后者不需要运行时（ssr、san核心）支持因此首选实现了。

## 使用方法

在 `<style>` 上加 `module`，在 `<template>` 和 `<script>` 中就可以直接使用 `$style` 来获取 CSS Modules 名字空间了：

```html
<template>
    <div class="{{$style.wrapper}}"></div>
</template>

<script>
export default {
    attached() {
        let style = this.data.get('$style');
        console.log(style);
    }
}
</script>

<style module>
.wrapper {
    color: black;
}
</style>
```

详情，可查看 diff 列表中的 packages/san-loader/README.md。

## 实现方式

1. 让 CSS 通过 webpack 机制经过 css-loader 并产出 CSS Modules。
2. 在 `.san` 的产出中收集所有 CSS Modules 并给到 normalizer。
3. 在 normalizer 中利用 `initData()` 把数据插入进去。

## 需要讨论/ review

1. 命名：`$style` 是否合适，当然后续可以支持配置，但这个默认的名字有没有更好的选择？
2. hook：现在 hook 到了 `initData()` 生命周期，是否合适
3. san-store：因为 `<script>` 可能是三种情况 san-store、构造 function、options对象，目前参考原来 `template` 的做法给 `comp`, `comp.prototype`, `comp.prototype.constructor.prototype` 都塞上去了。这肯定有问题：对于第二种情况就改了全局的原型。谁有更好的办法，我技穷了…

FYI：https://github.com/baidu/san-store/issues/27