### PR TITLE
build 命令 --report/statsJson 支持传入文件名

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,5 +1,3 @@
-
-
 # 生产打包
 
 `san build`是生产环境打包，下面详细说下用法。
@@ -32,9 +30,8 @@ san build [entry]
 
 -   `--analyze，--analyzer`：是否使用 webpack-analyze-bunlde 输出包分析，值为 true 或 false，默认 false
 -   `--profile`：是否展示编译进度日志，值为 true 或 false，默认是 false
--   `--report-json，--reportJson`：是否输将包分析报表生成为 report.json，值为 true 或 false，默认是 false
--   `--report`：是否输将包分析报表生成为单个 HTML 文件，值为 true 或 false，默认 false，仅生成 Webpack Stats JSON 文件
--   `--stats`：美化格式化输出
+-   `--report`：是否输将包分析报表生成为单个 HTML 文件，值为 true 或 false 或者文件名，默认 false，仅生成 Webpack Stats JSON 文件
+-   `--stats-json，--statsJson`：是否输将包分析报表生成为 stats.json，值为 true 或 false 或者文件名，默认是 false
 -   `--no-colors`：是否展示无色彩 log，值为 true 或 false，默认是 false
 
 ### 其他

--- a/packages/san-cli/__tests__/lib/utils.spec.js
+++ b/packages/san-cli/__tests__/lib/utils.spec.js
@@ -1,0 +1,38 @@
+/**
+ * @file inspect command tests
+ */
+/* global describe, test */
+const execSync = require('child_process').execSync;
+const {getReportFileName} = require('../../lib/utils');
+
+describe('lib/utils getReportFileName', () => {
+    test('default', () => {
+        const filename1 = getReportFileName(false, '');
+        expect(filename1).toEqual('report.html');
+        const filename2 = getReportFileName(false, '', 'stats.json');
+        expect(filename2).toEqual('stats.json');
+
+    });
+    test('prefixer', () => {
+        const filename1 = getReportFileName(false, 'modern-');
+        expect(filename1).toEqual('./modern-report.html');
+        const filename2 = getReportFileName(false, 'modern-', 'stats.json');
+        expect(filename2).toEqual('./modern-stats.json');
+    });
+    test('report.html prefixer', () => {
+        const filename1 = getReportFileName(true, 'modern-');
+        expect(filename1).toEqual('./modern-report.html');
+        const filename2 = getReportFileName(true, 'modern-', 'stats.json');
+        expect(filename2).toEqual('./modern-stats.json');
+    });
+    test('string path prefixer', () => {
+        const filename1 = getReportFileName('test/a/b', 'modern-');
+        expect(filename1).toEqual('test/a/modern-b.html');
+        const filename2 = getReportFileName('test.html', 'modern-', 'stats.json');
+        expect(filename2).toEqual('./modern-test.html');
+        const filename3 = getReportFileName('test', '', 'stats.json');
+        expect(filename3).toEqual('test.json');
+        const filename4 = getReportFileName('test', 'a', 'stats.json');
+        expect(filename4).toEqual('./atest.json');
+    });
+});

--- a/packages/san-cli/commands/build/getNormalizeWebpackConfig.js
+++ b/packages/san-cli/commands/build/getNormalizeWebpackConfig.js
@@ -7,7 +7,6 @@
  * @file 将 build 的 webpackConfig 处理拆出来
  * @author ksky521
  */
-
 const fse = require('fs-extra');
 const {resolveEntry} = require('san-cli-webpack/utils');
 const {error, chalk} = require('san-cli-utils/ttyLogger');
@@ -52,16 +51,18 @@ module.exports = function getNormalizeWebpackConfig(api, projectOptions, argv) {
     }
     else if (report || statsJson) {
         const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
+        const {getReportFileName} = require('../../lib/utils');
         // 单独标示 modern 打包
         const bundleName = modern ? (modernBuild ? 'modern-' : 'legacy-') : '';
-
+        const reportFilename = getReportFileName(report, bundleName, 'report.html');
+        const statsFilename = getReportFileName(statsJson, bundleName, 'stats.json');
         chainConfig.plugin('bundle-analyzer').use(
             new BundleAnalyzerPlugin({
                 logLevel: 'warn',
                 openAnalyzer: false,
-                analyzerMode: report ? 'static' : 'disabled',
-                reportFilename: `${bundleName}report.html`,
-                statsFilename: `${bundleName}stats.json`,
+                analyzerMode: 'static',
+                reportFilename,
+                statsFilename,
                 generateStatsFile: !!statsJson
             })
         );

--- a/packages/san-cli/commands/build/index.js
+++ b/packages/san-cli/commands/build/index.js
@@ -47,12 +47,10 @@ exports.builder = {
     },
     'stats-json': {
         alias: 'stats',
-        type: 'boolean',
         default: false,
         describe: 'Generate webpack stats JSON file'
     },
     'report': {
-        type: 'boolean',
         default: false,
         describe: 'Generate bundle report HTML file'
     },

--- a/packages/san-cli/lib/utils.js
+++ b/packages/san-cli/lib/utils.js
@@ -20,14 +20,15 @@ exports.requireFromLocal = cmd => {
             filepath = path.resolve(cmd);
             localModule = require(filepath);
             return filepath;
-        } catch (e) {
+        }
+        catch (e) {
             if (/Cannot find module/.test(e)) {
                 // 没有找到
                 return null;
-            } else {
-                localModule = undefined;
-                filepath = undefined;
             }
+            localModule = undefined;
+            filepath = undefined;
+
         }
     }
     if (localModule) {
@@ -49,3 +50,24 @@ function getCommandName(command) {
 exports.getCommandName = getCommandName;
 
 
+exports.getReportFileName = function getReportFileName(optFilename, prefixer = '', defaultFilename = 'report.html') {
+    let reportFileName = defaultFilename;
+    let defaultExtName = path.extname(defaultFilename);
+
+    if (typeof optFilename === 'string' && optFilename.length > 0) {
+        // 只支持json html htm
+        if (/\.(html?|json)$/.test(optFilename)) {
+            reportFileName = optFilename;
+        }
+        else {
+            reportFileName = optFilename + defaultExtName;
+        }
+    }
+    if (prefixer.length > 0) {
+        const baseName = path.basename(reportFileName);
+        const dirName = path.dirname(reportFileName);
+
+        reportFileName = `${dirName}/${prefixer}${baseName}`;
+    }
+    return reportFileName;
+};

--- a/packages/san-loader/__tests__/load-san-entry.spec.js
+++ b/packages/san-loader/__tests__/load-san-entry.spec.js
@@ -28,7 +28,7 @@ describe('.san 文件的产出', () => {
         expect(ctx.code).toContain('import template from');
         expect(ctx.code).toContain('import script from');
         expect(ctx.code).toContain('import style0 from');
-        expect(ctx.code).toContain('let injectStyles = [style0]');
+        expect(ctx.code).toContain('var injectStyles = [style0]');
         expect(ctx.code).toContain('export default normalize(script, template, injectStyles)');
     });
 

--- a/packages/san-loader/lib/blocks/style.js
+++ b/packages/san-loader/lib/blocks/style.js
@@ -24,7 +24,7 @@ const DEFAULT_STYLE_ATTR = {
  */
 function generateStyleImport(descriptor, options) {
     if (!descriptor.style || !descriptor.style.length) {
-        return 'let injectStyles = [];\n';
+        return 'var injectStyles = [];\n';
     }
 
     let injectStyles = [];
@@ -66,7 +66,7 @@ function generateStyleImport(descriptor, options) {
             code += `import '${resource}';\n`;
         }
     }
-    code += `let injectStyles = [${injectStyles.join(', ')}];\n`;
+    code += `var injectStyles = [${injectStyles.join(', ')}];\n`;
 
     return code;
 }


### PR DESCRIPTION
build增加对产出stats和报告的文件名支持，默认还是`false`