### PR TITLE
1. 修复 san-cli-ui 的 1 个 bug；2. 修改文档的错误。

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ San CLI 中的 logger 是通过自定义的 Consola Reporter 实现的，在插�
 
 1. 流程：CLI 的流程分为两段，主流程和 Service 流程；
     1. 主流程：`index.js`的流程，是整个 CLI 的工作流程，如果有自定义的 command，则会执行对应的 handler；如果主流程没有相关命令，则会走到`default`，`default`会实例化 Service，进入 Service 流程；
-    2. Service 流程：CLI 的 Service 层设计，主要进行 Webpack 构建相关的处理逻辑；可以通过 Service 插件的`api.registerCommand`方法注册 Service 流程的命令；
+    2. Service 流程：CLI 的 Service 层设计，主要进行 Webpack 构建相关的处理逻辑；
     3. P.S：`build`、`serve`、`inspect`都是走的 Service 流程。
 2. Command：指的是通过[yargs](https://github.com/yargs/yargs/)创建的命令行 bin 工具，它可以通过`.sanrc`的`commands`字段对命令进行扩展；
 3. Command 插件：指通过给 Command 添加自定义命令的方式，添加 Command 插件，这样的插件可以使用`san your_command_name [options]`方式在主流程触发；
@@ -221,14 +221,12 @@ module.exports = {
 常见方法包括：
 
 -   `.isProd()`：是不是生产环境打包，`process.NODD_ENV==='production'`；
--   `.registerCommand(name, handler)`：注册 command 命令，实例化 Service 之后执行`service.run(command, argv)`触发；
 -   `.configWebpack(fn)`：将`fn` 压入 webpackConfig 回调栈，`fn`会在出栈执行时接收 webpackConfig，用于修改 webpack config；
 -   `.chainWebpack(fn)`：将`fn` 压入 webpackChain 回调栈，`fn`会在出栈执行时接收 chainableConfig，用于 webpack-chain 语法修改 webpack config；
 -   `.resolve(p)`：获取 CLI 执行目录的完整路径；
 -   `.getWebpackChainConfig()`：获取 webpack-chain 格式的 config；
 -   `.getWebpackConfig([chainableConfig])`：将传入的 webpack-chain 格式 config 处理成 webpackConfig 返回；
 -   `.getCwd()`：获取 CLI 的执行目录；
--   `.getProjectOptions()`：获取项目的配置内容；
 -   `.getVersion()`：获取 CLI 版本；
 -   `.getPkg()`：获取当前项目`package.json`内容；
 -   `.addPlugin(plugin, options)`：添加插件；

--- a/packages/san-cli-ui/client/pages/plugins/content.js
+++ b/packages/san-cli-ui/client/pages/plugins/content.js
@@ -29,7 +29,7 @@ export default class Plugins extends Component {
                     <fragment slot="content">
                         <s-radio-group
                             name="radiogroup"
-                            defaultValue="plugin"
+                            defaultValue="{{radioValue}}"
                             on-change="onRadioChange"
                             class="pkg-radio">
                             <s-radio-button value="plugin">


### PR DESCRIPTION
修复 bug：插件安装弹窗中，选了第二个tab后关闭弹窗，再打开弹窗，选中的tab变成了第一个，但列表数据还是二个tab的。


