### PR TITLE
:bug: 修复输出打包分析不可用的问题

### DIFF
--- a/docs/bundle-analyze.md
+++ b/docs/bundle-analyze.md
@@ -12,10 +12,10 @@ San CLI 内置了[webpack-bundle-analyzer](https://github.com/webpack-contrib/we
 
 ## 分析结果
 
-除了直接使用 webpack-bundle-analyzer 查看结果，还可以将 Bundle 结果保存下来，用于分析和比较两次打包的结果，查找是否打包合理，San CLI 的 build 使用下面的两个方式来将分析结果进行保存：
+除了直接使用 webpack-bundle-analyzer 查看结果，还可以将 Bundle 结果保存下来，用于分析和比较两次打包的结果，查看是否打包合理，San CLI 的 build 使用下面的两个参数来将分析结果进行保存：
 
--   `--stats-json，--stats`：生成 Webpack stats JSON 文件到 stats.json，值为 true 或 false，默认是 false
--   `--report`：是否输将包分析报表生成为单个 HTML 文件，值为 true 或 false，默认 false，仅生成 Webpack Stats JSON 文件
+-   `--stats-json，--stats`：生成 Webpack stats JSON 文件到 stats.json
+-   `--report`：将包分析报表生成为单个 HTML 文件
 
 关于 Bundle 结果的分析可以查看[这篇文章](https://survivejs.com/webpack/optimizing/build-analysis/)介绍了很多 Bundle 分析工具。这些工具的使用方法都是将生成的报告 JSON 地址上传上去，然后分析，这里就不再赘余了。
 

--- a/packages/san-cli/commands/build/getNormalizeWebpackConfig.js
+++ b/packages/san-cli/commands/build/getNormalizeWebpackConfig.js
@@ -60,7 +60,7 @@ module.exports = function getNormalizeWebpackConfig(api, projectOptions, argv) {
             new BundleAnalyzerPlugin({
                 logLevel: 'warn',
                 openAnalyzer: false,
-                analyzerMode: 'static',
+                analyzerMode: statsJson ? 'disabled' : 'static',
                 reportFilename,
                 statsFilename,
                 generateStatsFile: !!statsJson

--- a/packages/san-cli/commands/build/index.js
+++ b/packages/san-cli/commands/build/index.js
@@ -47,10 +47,12 @@ exports.builder = {
     },
     'stats-json': {
         alias: 'stats',
+        type: 'boolean',
         default: false,
         describe: 'Generate webpack stats JSON file'
     },
     'report': {
+        type: 'boolean',
         default: false,
         describe: 'Generate bundle report HTML file'
     },


### PR DESCRIPTION
即 san build --stats 和 san build --report 这两个命令。
同时也优化了一下输出打包分析的逻辑：原来执行 san build --report 时也会生成 json 文件，但是生成 json 文件耗时很长，现在改成了 --report 就只生成 html 文件。--stats 也是只生成 json 文件（和原来一样）。