### PR TITLE
1. 修复因升级 4.0 而坏掉的测试用例；2. 修复 resolveLocal 函数的路径错误的问题；3. 暂时去掉 @sdoc/cli；4. 优化文档和注释；5. 解决前人的代码规范问题。

### DIFF
--- a/docs/browser-compatibility.md
+++ b/docs/browser-compatibility.md
@@ -3,23 +3,23 @@
 
 ## browserslist
 
-用户可以通过项目中的 `package.json`中`browserslist` 字段 (或 `.browserslistrc`文件)来指定了项目的目标浏览器的范围。这个配置会被 `@babel/preset-env` 和 `Autoprefixer` 用来确定需要转译的JavaScript特性和需要添加的CSS浏览器前缀（[了解更多](https://github.com/browserslist/browserslist)）。
+用户可以通过项目中的 `package.json` 中 `browserslist` 字段 (或 `.browserslistrc` 文件)来指定项目的目标浏览器的范围。这个配置会被 `@babel/preset-env` 和 `Autoprefixer` 用来确定需要转译的 JavaScript 特性和需要添加的 CSS 浏览器前缀（[了解更多](https://github.com/browserslist/browserslist)）。
 
 
 ## Polyfill
 
-Polyfill是指一段JS代码，它提供了开发者希望浏览器能够原生提供的技术，目标是打平开发环境和用户浏览器之间的API兼容性差异。
+Polyfill 是指一段 JS 代码，它提供了开发者希望浏览器能够原生提供的技术，目标是打平开发环境和用户浏览器之间的 API 兼容性差异。
 
-在San CLI中通过 @babel/preset-env 和 browserslist 配置来决定项目需要的 polyfill。
+在 San CLI 中通过 @babel/preset-env 和 browserslist 配置来决定项目需要的 polyfill。
 
-默认情况下，我们会把 `useBuiltIns: 'usage'` 传递给`@babel/preset-env`，这样它会根据源代码中出现的语言特性自动检测需要的Polyfill，这确保了最终包里 Polyfill 数量的最小化。
+默认情况下，我们会把 `useBuiltIns: 'usage'` 传递给 `@babel/preset-env`，这样它会根据源代码中出现的语言特性自动检测需要的Polyfill，这确保了最终包里 Polyfill 数量的最小化。
 
 
 ### 个性化配置
 
-1. 使用`exclude`参数来去掉不需要的polyfill；
+1. 使用 `exclude` 参数来去掉不需要的polyfill；
 
-```
+```js
 module.export = {
     // ...
     loaderOptions: {
@@ -33,9 +33,9 @@ module.export = {
 ```
 
 
-2. 通过`polyfills`参数强制引入polyfill（主要解决自动添加存在的一些兼容性问题）；
+2. 通过 `polyfills` 参数强制引入 polyfill（主要解决自动添加存在的一些兼容性问题）；
 
-```
+```js
 module.export = {
     // ...
     loaderOptions: {
@@ -44,7 +44,6 @@ module.export = {
                 'es.promise',
                 // #2012 es7.promise replaces native Promise in FF and causes missing finally
                 'es.promise.finally',
-
                 // Promise polyfill alone doesn't work in IE
                 'es.array.iterator'
             ]
@@ -55,9 +54,9 @@ module.export = {
 
 ```
 
-3. 禁用内置Polyfill配置，即不使用san-cli提供的presets，babel-loader会自动找项目目录下的babel配置文件（`.babelrc` > `babel.config.js`）：
+3. 禁用内置 Polyfill 配置，即不使用 san-cli 提供的 presets，babel-loader 会自动找项目目录下的 babel 配置文件（`.babelrc` > `babel.config.js`）：
 
-```
+```js
 module.export = {
     // ...
     loaderOptions: {
@@ -66,4 +65,3 @@ module.export = {
 }
 
 ```
-

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         "@commitlint/core": "^8.3.4",
         "@ecomfe/eslint-config": "^3.2.0",
         "@ksky521/cz-emoji": "^1.2.1",
-        "@sdoc/cli": "^1.0.2",
         "babel-eslint": "^10.1.0",
         "commitizen": "^4.0.3",
         "commitlint-config-gitmoji": "1.0.1",

--- a/packages/san-cli-config-webpack/index.js
+++ b/packages/san-cli-config-webpack/index.js
@@ -1,5 +1,3 @@
-const path = require('path');
-const fs = require('fs');
 const lMerge = require('lodash.merge');
 const Config = require('webpack-chain');
 const {devServerOptions} = require('./defaultOptions');

--- a/packages/san-cli-config-webpack/rules/sass.js
+++ b/packages/san-cli-config-webpack/rules/sass.js
@@ -1,6 +1,4 @@
 const createCSSRule = require('./createCSSRule');
-const {error} = require('san-cli-utils/ttyLogger');
-const semver = require('semver');
 
 module.exports = (
     chainConfig,

--- a/packages/san-cli-config-webpack/rules/script.js
+++ b/packages/san-cli-config-webpack/rules/script.js
@@ -1,2 +1,1 @@
-const resolve = require('resolve');
-module.exports = (chainConfig) => {};
+module.exports = () => {};

--- a/packages/san-cli-config-webpack/utils.js
+++ b/packages/san-cli-config-webpack/utils.js
@@ -19,8 +19,8 @@ exports.defineVar = (projectOptions, raw) => {
         return vars;
     }
 
-    for (const key in vars) {
-        vars[key] = JSON.stringify(vars[key]);
+    for (const [key, value] of Object.entries(vars)) {
+        vars[key] = JSON.stringify(value);
     }
     return vars;
 };
@@ -44,7 +44,7 @@ exports.normalizeProjectOptions = projectOptions => {
             return projectOptions.mode === 'production';
         },
         resolveLocal(...args) {
-            return path.join(__dirname, '../', ...args);
+            return path.join(__dirname, ...args);
         },
         resolve(p) {
             if (p) {
@@ -57,5 +57,5 @@ exports.normalizeProjectOptions = projectOptions => {
 
 
 exports.resolveLocal = (...args) => {
-    return path.join(__dirname, '../', ...args);
+    return path.join(__dirname, ...args);
 };

--- a/packages/san-cli-plugin-babel/__tests__/preset.spec.js
+++ b/packages/san-cli-plugin-babel/__tests__/preset.spec.js
@@ -20,19 +20,20 @@ const defaultOptions = {
 test('默认值', () => {
     const presets = preset().presets;
     expect(presets[0][1]).toEqual({
+        bugfixes: true,
         debug: false,
+        exclude: [],
         loose: false,
-        ignoreBrowserslistConfig: undefined,
         useBuiltIns: 'usage',
-        corejs: 3,
-        targets: undefined,
+        corejs: require('core-js/package.json').version,
+        targets: {},
         modules: false
     });
 });
 
 test('添加 plugin', () => {
     const plugins = preset({plugins: [{id: 'a'}]}).plugins;
-    expect(plugins.length).toBe(7);
+    expect(plugins.length).toBe(8);
 });
 
 test('检测 polyfill', () => {

--- a/packages/san-cli-serve/public/main.js
+++ b/packages/san-cli-serve/public/main.js
@@ -11,4 +11,5 @@
 import {defineComponent} from 'san';
 import App from '~entry';
 const Component = defineComponent(App);
+// eslint-disable-next-line no-unused-vars
 const app = new Component();

--- a/packages/san-cli-service/__tests__/PluginAPI.spec.js
+++ b/packages/san-cli-service/__tests__/PluginAPI.spec.js
@@ -13,8 +13,8 @@ const path = require('path');
 
 let pluginApi = null;
 beforeEach(() => {
+    process.env.NODE_ENV = 'production';
     pluginApi = new PluginAPI('plugin-yyt', {
-        mode: 'production',
         webpackChainFns: [],
         webpackRawConfigFns: [],
         cwd: 'user/yyt'

--- a/packages/san-cli/__tests__/e2e.spec.js
+++ b/packages/san-cli/__tests__/e2e.spec.js
@@ -228,7 +228,7 @@ test('serve 命令和 build 命令的 E2E 测试', done => {
                 // 测试点31：产出中的 classname 是否正确（css module）（测 san.conifg 的 css.requireModuleExtension）
                 expect(indexJSContent).toEqual(expect.stringContaining('_main_'));
 
-                // 测试点32：大于配置大小的图片是否没编译成 base64
+                // 测试点32：大于配置大小的图片是否没编译成 base64（测 san.config 的 largeAssetSize）
                 expect(indexJSContent).toEqual(expect.not.stringContaining('data:image'));
 
                 done();

--- a/packages/san-cli/__tests__/e2e.spec.js
+++ b/packages/san-cli/__tests__/e2e.spec.js
@@ -83,7 +83,7 @@ test('serve 命令和 build 命令的 E2E 测试', done => {
                     if (isFirstCompilation) {
                         isFirstCompilation = false;
                     } else {
-                        // 等待页面内容更新
+                        // 等待页面内容更新，如果超时了那应该就是你把代码改坏了，导致 HMR 失效了
                         await page.waitForFunction(
                             selector => document.querySelector(selector).textContent.includes('updated'), {}, 'h2'
                         );


### PR DESCRIPTION
现在测试用例都能跑通了，不过安装依赖时得把 @sdoc/cli 暂时给删了，不然跑不通（还是因为之前我说的那个 2 个 webpack 版本的问题）。