### PR TITLE
:sparkles: 在 script 里面补充 sdoc 的安装逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     },
     "scripts": {
         "commit": "git-cz",
-        "doc": "sdoc start docs",
-        "build:doc": "sdoc build docs",
+        "doc": "npx @sdoc/cli start docs",
+        "build:doc": "npx @sdoc/cli build docs",
         "lint": "eslint --ignore-path .eslintignore ./",
         "test": "rimraf ./packages/test && node scripts/test.js"
     },


### PR DESCRIPTION
之所以用 npx 安装 的 sdoc，是因为直接安装 sdoc 会导致 2 个 webpack 版本的 bug。
感觉这样已经完美解决问题了，可以暂时完全不考虑把 sdoc 也升级到 webpack 5 了。