### PR TITLE
升级 svg-sprite-loader

### DIFF
--- a/packages/san-cli-config-webpack/package.json
+++ b/packages/san-cli-config-webpack/package.json
@@ -32,7 +32,7 @@
         "san-loader": "^0.2.0",
         "semver": "^7.1.1",
         "style-loader": "~2.0.0",
-        "svg-sprite-loader": "^5.2.1",
+        "svg-sprite-loader": "^6.0.9",
         "svg-url-loader": "^7.1.1",
         "url-loader": "^4.1.1",
         "webpack": "^5.38.1",


### PR DESCRIPTION
升级 svg-sprite-loader 是为了修复下图中的第一个红框中的问题；

![image](https://user-images.githubusercontent.com/28821810/125622677-bcdb3082-eca7-4189-9a17-fb1530d6dd2d.png)