### PR TITLE
1. 增加检查 css map 的 E2E 测试 2. 去掉警告和错误日志里的很多不必要的东西 3. 升级 san-loader（san-cli 体积能减小 30%） 4. serve 命令支持零配置调试 .san 文件

### DIFF
--- a/packages/san-cli-config-webpack/package.json
+++ b/packages/san-cli-config-webpack/package.json
@@ -28,7 +28,7 @@
         "san-cli-utils": "^1.0.3",
         "san-cli-webpack": "^2.0.0",
         "san-hot-loader": "^0.1.2",
-        "san-loader": "^0.2.0",
+        "san-loader": "^0.3.0",
         "semver": "^7.1.1",
         "style-loader": "~2.0.0",
         "svg-sprite-loader": "^6.0.9",

--- a/packages/san-cli-serve/public/main.js
+++ b/packages/san-cli-serve/public/main.js
@@ -13,3 +13,4 @@ import App from '~entry';
 const Component = defineComponent(App);
 // eslint-disable-next-line no-unused-vars
 const app = new Component();
+app.attach(document.getElementById('app'));

--- a/packages/san-cli-service/Service.js
+++ b/packages/san-cli-service/Service.js
@@ -225,7 +225,7 @@ module.exports = class Service extends EventEmitter {
         // 下面是给cnfig-webpack用的
         projectOptions.mode = mode;
 
-        const entryFiles = Object.keys(projectOptions.pages).map(key => projectOptions.pages[key].entry);
+        const entryFiles = Object.keys(projectOptions.pages || {}).map(key => projectOptions.pages[key].entry);
         process.env.SAN_CLI_ENTRY_FILES = JSON.stringify(entryFiles);
 
         debug('projectOptions: %O', projectOptions);

--- a/packages/san-cli-webpack/lib/SanFriendlyErrorsPlugin.js
+++ b/packages/san-cli-webpack/lib/SanFriendlyErrorsPlugin.js
@@ -55,11 +55,6 @@ function isLikelyASyntaxError(message) {
 
 // Cleans up webpack error messages.
 function formatMessage(message) {
-    // 兼容webpack5升级
-    if (typeof message === 'object') {
-        message = Object.values(message).join('\n');
-    }
-
     let lines = message.split('\n');
 
     // Strip webpack-added headers off errors/warnings
@@ -113,10 +108,10 @@ function formatMessage(message) {
 }
 
 function formatWebpackMessages(json) {
-    const formattedErrors = json.errors.map(function (message) {
+    const formattedErrors = json.errors.map(function ({message}) {
         return formatMessage(message, true);
     });
-    const formattedWarnings = json.warnings.map(function (message) {
+    const formattedWarnings = json.warnings.map(function ({message}) {
         return formatMessage(message, false);
     });
     const result = {errors: formattedErrors, warnings: formattedWarnings};

--- a/packages/san-cli-webpack/utils.js
+++ b/packages/san-cli-webpack/utils.js
@@ -58,12 +58,16 @@ exports.resolveEntry = (resolveEntryPath, absoluteEntryPath, webpackConfig, defa
         const isFile = obj.isFile;
 
         webpackConfig.entry = webpackConfig.entry || {};
-        if (isFile && !/\.san$/.test(resolveEntryPath)) {
+        const isSanFile = /\.san$/.test(resolveEntryPath);
+        if (isFile && !isSanFile) {
             webpackConfig.entry.app = resolveEntryPath;
         } else {
             webpackConfig.entry.app = defaultEntry;
             // san 文件/目录的情况需要指定 ~entry
             webpackConfig.resolve.alias['~entry'] = absoluteEntryPath;
+        }
+        if (isSanFile) {
+            webpackConfig.cache = false;
         }
     }
     // 处理 entry 不存在的情况

--- a/packages/san-cli/__tests__/e2e.spec.js
+++ b/packages/san-cli/__tests__/e2e.spec.js
@@ -89,7 +89,7 @@ test('serve 命令和 build 命令的 E2E 测试', done => {
                 console.error(`serve stderr: ${data}`);
             });
             serve.stdout.on('data', async data => {
-                console.log(`init stdout: ${data}`);
+                console.log(`serve stdout: ${data}`);
                 const urlMatch = data.toString().match(/http:\/\/[\d\.:]+/);
                 // 是否输出了 URL（输出了 URL 意味着服务起来了）
                 if (urlMatch) {
@@ -202,8 +202,10 @@ test('serve 命令和 build 命令的 E2E 测试', done => {
                 expect(demoJSContent).toEqual(expect.not.stringMatching(/;\n(?!\/)/));
 
                 const indexJSMapFileName = jsDir.find(filename => filename.match(/^(index.)[a-z0-9]+(.js.map)$/));
+                const indexCSSMapFileName = cssDir.find(filename => filename.match(/^(index.)[a-z0-9]+(.css.map)$/));
                 // 测试点16：是否产出了 .map 文件（测 san.config 的 sourceMap)
                 expect(indexJSMapFileName).toBeDefined();
+                expect(indexCSSMapFileName).toBeDefined();
 
                 const vendorsLegacyJSMapFileName = jsDir.find(
                     filename => filename.match(/^(vendors-legacy.)[a-z0-9]+(.js.map)$/)
@@ -273,8 +275,10 @@ test('serve 命令和 build 命令的 E2E 测试', done => {
                 expect(indexJSContent).toEqual(expect.stringMatching(/;\n(?!\/)/));
 
                 const indexJSMapPath = path.join(outputPath, 'index.js.map');
+                const indexCSSMapPath = path.join(outputPath, 'index.css.map');
                 // 测试点30：是否没产出 .map 文件（测 san.config 的 sourceMap)
                 expect(fse.existsSync(indexJSMapPath)).toBeFalsy();
+                expect(fse.existsSync(indexCSSMapPath)).toBeFalsy();
 
                 // 测试点31：产出中的 classname 是否正确（css module）（默认启用css modules）
                 expect(indexJSContent).toEqual(expect.stringContaining('_main_'));

--- a/packages/san-cli/__tests__/san-file/hello.san
+++ b/packages/san-cli/__tests__/san-file/hello.san
@@ -1,0 +1,19 @@
+<template>
+    <div class="content">Hello {{name}}!</div>
+</template>
+
+<script>
+    export default {
+        initData() {
+            return {
+                name: 'San'
+            };
+        }
+    };
+</script>
+
+<style>
+    .content {
+        color: blue;
+    }
+</style>

--- a/packages/san-cli/__tests__/serveSan.spec.js
+++ b/packages/san-cli/__tests__/serveSan.spec.js
@@ -1,0 +1,40 @@
+jest.setTimeout(30000);
+
+const child_process = require('child_process');
+const puppeteer = require('puppeteer');
+const rimraf = require('rimraf');
+const path = require('path');
+
+const isWindows = process.platform === 'win32';
+
+test('测试 serve .san 文件', done => {
+    rimraf.sync(path.join(__dirname, '../../../node_modules/.cache'));
+    const serve = child_process.spawn(
+        'san',
+        ['serve', './packages/san-cli/__tests__/san-file/hello.san'],
+        {shell: isWindows}
+    );
+    serve.stderr.on('data', data => {
+        // eslint-disable-next-line no-console
+        console.error(`stderr: ${data}`);
+    });
+    serve.stdout.on('data', async data => {
+        // eslint-disable-next-line no-console
+        console.log(`stdout: ${data}`);
+        const urlMatch = data.toString().match(/http:\/\/[\d\.:]+/);
+        if (urlMatch) {
+            const browser = await puppeteer.launch();
+            const page = await browser.newPage();
+            await page.goto(urlMatch[0]);
+            const text = await page.evaluate(() => document.querySelector('.content').textContent);
+            expect(text).toMatch('Hello San!');
+            await browser.close();
+            if (isWindows) {
+                child_process.spawn('taskkill', ['/pid', serve.pid, '/f', '/t']);
+            } else {
+                serve.kill();
+            }
+            done();
+        }
+    });
+});


### PR DESCRIPTION
去掉警告和错误日志里的很多不必要的东西：
![e17fd389d9657d7eeaefd2d7206ad7d6](https://user-images.githubusercontent.com/28821810/126316286-956af2e8-423a-4d44-9ef3-cb506a5a4a47.jpg)

旧版 san-loader 30 多M，新版几百K：
![image](https://user-images.githubusercontent.com/28821810/126316786-22ecc5a2-9e82-47f0-a760-6f98883e28ca.png)
