### PR TITLE
:bug: 修复 html 文件里不能写自闭合标签的问题

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -169,7 +169,8 @@ San CLI 中使用的 html-webpack-plugin 的配置项中可以使用 html-minifi
     removeScriptTypeAttributes: false,
     minifyCSS: true,
     // 处理 smarty 和 php 情况
-    ignoreCustomFragments: [/{%[\s\S]*?%}/, /<%[\s\S]*?%>/, /<\?[\s\S]*?\?>/]
+    ignoreCustomFragments: [/{%[\s\S]*?%}/, /<%[\s\S]*?%>/, /<\?[\s\S]*?\?>/],
+    keepClosingSlash: true
     // more options:
     // https://github.com/kangax/html-minifier#options-quick-reference
 }

--- a/packages/san-cli-config-webpack/defaultOptions.js
+++ b/packages/san-cli-config-webpack/defaultOptions.js
@@ -69,7 +69,8 @@ exports.htmlMinifyOptions = {
     removeScriptTypeAttributes: false,
     minifyCSS: true,
     // 处理 smarty 和 php 情况
-    ignoreCustomFragments: [/{%[\s\S]*?%}/, /<%[\s\S]*?%>/, /<\?[\s\S]*?\?>/]
+    ignoreCustomFragments: [/{%[\s\S]*?%}/, /<%[\s\S]*?%>/, /<\?[\s\S]*?\?>/],
+    keepClosingSlash: true
     // more options:
     // https://github.com/kangax/html-minifier#options-quick-reference
 };


### PR DESCRIPTION
相关 discussion：https://github.com/baidu/san/discussions/652
3.0 没问题是因为 3.0 用的是低版本的 html-loader，低版本的默认不会把自闭合标签的斜杠删除，而 4.0 用的高版本的 html-loader默认把自闭合标签的斜杠删除了。
该改动需要更新官网。